### PR TITLE
AIR-33014: Maps allow integers as keys

### DIFF
--- a/lib/avro/datum.php
+++ b/lib/avro/datum.php
@@ -242,7 +242,7 @@ class AvroIODatumWriter
       $encoder->write_long($datum_count);
       foreach ($datum as $k => $v)
       {
-        $encoder->write_string($k);
+        $encoder->write_string((string) $k);
         $this->write_data($writers_schema->values(), $v, $encoder);
       }
     }

--- a/lib/avro/schema.php
+++ b/lib/avro/schema.php
@@ -446,7 +446,7 @@ class AvroSchema
         if (is_array($datum))
         {
           foreach ($datum as $k => $v)
-            if (!is_string($k)
+            if ((!is_string($k) && !is_int($k))
                 || !self::is_valid_datum($expected_schema->values(), $v))
               return false;
           return true;


### PR DESCRIPTION
Added support so maps allow both strings and ints as keys.

Keys in PHP arrays will [automatically cast to integers](https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax.array-func) if all characters are integer digits.  This change allows both strings and ints in the validation and then casts the key to a string when doing the actual encoding.

e.g.
```
{
  "mapContainer": {
    123: "value1",    // invalid before because it's an int, ok now
    "456": "value2",  // invalid before because array key gets converted to int, ok now
    "0789": "value3", // ok, stays as string because starts with a zero
    "myKey": "value4" // ok, stays as a string because not all int characters
  }
}
```